### PR TITLE
fix possible DMA deadlock if size <= 0

### DIFF
--- a/sw/runtime/include/handler.h
+++ b/sw/runtime/include/handler.h
@@ -88,8 +88,14 @@ typedef struct spin_rw_lock {
 
 static inline int spin_dma(void* source, void* dest, size_t size, int direction, int options, spin_dma_t* xfer)
 {
-    *xfer = spin__memcpy_nonblk(source, dest, (uint32_t)size);
-    return SPIN_OK;
+    if (__builtin_expect(size>0, 1))
+    {
+        *xfer = spin__memcpy_nonblk(source, dest, (uint32_t)size);
+        return SPIN_OK;
+    } else
+    {
+        return SPIN_FAIL;  
+    }
 }
 
 static inline int spin_dma_wait(spin_dma_t xfer)


### PR DESCRIPTION
When passed a size of 0 or less, spin__memcpy_nonblk will most likely deadlock.
Fixed by adding a case distinction over the size. The expectation is, that the if statement nearly always evaluates to 1.