### PR TITLE
examples: add support for multiple ECs

### DIFF
--- a/examples/aggregate/driver/driver.c
+++ b/examples/aggregate/driver/driver.c
@@ -22,8 +22,9 @@ int main(int argc, char**argv)
     const char *ph="aggregate_global_ph";
     const char *th="aggregate_global_th";
 
-    gdriver_init(argc, argv, handlers_file, hh, ph, th);
-   
+    gdriver_init(argc, argv);
+    gdriver_add_ectx(handlers_file, hh, ph, th, NULL, NULL, 42);
+
     gdriver_run();
 
     gdriver_fini();

--- a/examples/aggregate_and_reduce/Makefile
+++ b/examples/aggregate_and_reduce/Makefile
@@ -1,0 +1,7 @@
+SPIN_APP_NAME = aggregate_and_reduce
+SPIN_APP_SRCS = handlers/aggregate_and_reduce.c
+SPIN_CFLAGS = -O3 -g
+SPIN_LDFLAGS = -lm
+
+include $(PSPIN_RT)/rules/spin-handlers.mk
+include ../generic_driver/gdriver.mk

--- a/examples/aggregate_and_reduce/driver/driver.c
+++ b/examples/aggregate_and_reduce/driver/driver.c
@@ -15,19 +15,27 @@
 #include <stdint.h>
 #include "gdriver.h"
 
-
 int main(int argc, char**argv)
 {
-    const char *handlers_file="build/reduce_l1";
-    const char *hh=NULL;
-    const char *ph="reduce_l1_ph";
-    const char *th="reduce_l1_th";
+    const char *handlers_file = "build/aggregate_and_reduce";
+
+    const char *hh_aggregate = NULL;
+    const char *ph_aggregate = "aggregate_global_ph";
+    const char *th_aggregate = "aggregate_global_th";
+
+    const char *hh_reduce = NULL;
+    const char *ph_reduce = "reduce_l1_ph";
+    const char *th_reduce = "reduce_l1_th";
 
     gdriver_init(argc, argv);
-    gdriver_add_ectx(handlers_file, hh, ph, th, NULL, NULL, 42);
+
+    gdriver_add_ectx(handlers_file, hh_aggregate, ph_aggregate, th_aggregate,
+        NULL, NULL, 42);
+    gdriver_add_ectx(handlers_file, hh_reduce, ph_reduce, th_reduce, NULL, NULL, 42);
 
     gdriver_run();
 
     gdriver_fini();
+
     return 0;
 }

--- a/examples/aggregate_and_reduce/handlers/aggregate_and_reduce.c
+++ b/examples/aggregate_and_reduce/handlers/aggregate_and_reduce.c
@@ -1,0 +1,121 @@
+// Copyright 2020 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef HOST
+#include <handler.h>
+#else
+#include <handler_profiler.h>
+#endif
+
+#include <packets.h>
+
+#define MAX_CLUSTERS 4
+#define MAX_HPUS 32
+#define STRIDE 1
+#define OFFSET 0
+#define NUM_INT_OP 0
+#define ZEROS 2048
+
+// Handler that implements data race free aggregation for int32
+
+__handler__ void aggregate_global_ph(handler_args_t *args)
+{
+
+    task_t* task = args->task;
+    uint32_t *scratchpad = (uint32_t *)task->scratchpad;
+
+    uint8_t *pkt_pld_ptr;
+    uint32_t pkt_pld_len;
+    GET_IP_UDP_PLD(task->pkt_mem, pkt_pld_ptr, pkt_pld_len);
+
+    uint32_t *nic_pld_addr = (uint32_t*) pkt_pld_ptr;
+
+    uint32_t aggregator=0;
+    for(uint32_t i=0;i<pkt_pld_len/4;i++)
+    {
+      aggregator+=nic_pld_addr[i*STRIDE+OFFSET];
+    }
+
+    uint32_t my_cluster_id = args->cluster_id;
+    amo_add(&(scratchpad[my_cluster_id]), aggregator);
+}
+
+__handler__ void aggregate_global_th(handler_args_t *args)
+{
+    task_t* task = args->task;
+    uint32_t *scratchpad=(uint32_t*) task->scratchpad;
+    uint32_t result=0;
+    for(uint8_t i=0;i<MAX_CLUSTERS;i++){
+        result+=scratchpad[i];
+    }
+    //printf("final result %u\n",result);
+    uint64_t host_address = task->host_mem_high;
+    host_address = (host_address << 32) | (task->host_mem_low);
+
+    spin_host_write(host_address, (uint64_t) result, false);
+}
+
+void init_handlers(handler_fn * hh, handler_fn *ph, handler_fn *th, void **handler_mem_ptr)
+{
+    volatile handler_fn handlers[] = {NULL, aggregate_global_ph, aggregate_global_th};
+    *hh = handlers[0];
+    *ph = handlers[1];
+    *th = handlers[2];
+}
+
+// Handler that implements reduce in scratchpad for int32
+
+// 4 uint32_t -> locks
+// 4 uint32_t -> L1 addresses
+// 1 uint32_t -> msg_count (now 0x0200)
+
+__handler__ void reduce_l1_ph(handler_args_t *args)
+{
+
+    task_t* task = args->task;
+
+    uint8_t *pkt_pld_ptr;
+    uint32_t pkt_pld_len;
+    GET_IP_UDP_PLD(task->pkt_mem, pkt_pld_ptr, pkt_pld_len);
+
+    uint32_t *nic_pld_addr = (uint32_t*) pkt_pld_ptr;
+
+    //reduce_mem_t *mem = (reduce_mem_t *)args->her->match_info.handler_mem;
+    volatile int32_t *local_mem = (int32_t *)(task->scratchpad[args->cluster_id]);
+
+    //we assume the number of msg size divides the pkt payload size
+    for (uint32_t i = 0; i < pkt_pld_len / 4; i++)
+    {
+        amo_add(&(local_mem[i]), nic_pld_addr[i]);
+    }
+    // We do need atomics here, as each handler writes to the same adress as others in the same cluster.
+}
+__handler__ void reduce_l1_th(handler_args_t *args)
+{
+    task_t* task = args->task;
+    uint64_t host_address = task->host_mem_high;
+    host_address = (host_address << 32) | (task->host_mem_low);
+
+    //signal that we completed so to let the host read the result back
+    spin_host_write(host_address, (uint64_t) 1, false);
+}
+
+
+void init_handlers2(handler_fn *hh, handler_fn *ph, handler_fn *th, void **handler_mem_ptr)
+{
+    volatile handler_fn handlers[] = {NULL, reduce_l1_ph, reduce_l1_th};
+    *hh = handlers[0];
+    *ph = handlers[1];
+    *th = handlers[2];
+}

--- a/examples/copy_from_host/driver/driver.c
+++ b/examples/copy_from_host/driver/driver.c
@@ -22,8 +22,9 @@ int main(int argc, char**argv)
     const char *ph="copy_from_host_ph";
     const char *th=NULL;
 
-    gdriver_init(argc, argv, handlers_file, hh, ph, th);
-   
+    gdriver_init(argc, argv);
+    gdriver_add_ectx(handlers_file, hh, ph, th, NULL, NULL, 42);
+
     gdriver_run();
 
     gdriver_fini();

--- a/examples/copy_to_host/driver/driver.c
+++ b/examples/copy_to_host/driver/driver.c
@@ -22,8 +22,9 @@ int main(int argc, char**argv)
     const char *ph="copy_to_host_ph";
     const char *th=NULL;
 
-    gdriver_init(argc, argv, handlers_file, hh, ph, th);
-   
+    gdriver_init(argc, argv);
+    gdriver_add_ectx(handlers_file, hh, ph, th, NULL, NULL, 42);
+
     gdriver_run();
 
     gdriver_fini();

--- a/examples/empty/driver/driver.c
+++ b/examples/empty/driver/driver.c
@@ -16,7 +16,7 @@
 #include "gdriver.h"
 
 uint32_t fill_packet(uint32_t msg_idx, uint32_t pkt_idx, uint8_t *pkt_buff, uint32_t max_pkt_size, uint32_t* l1_pkt_size)
-{   
+{
     // nothing to do here
 
     return max_pkt_size;
@@ -29,9 +29,9 @@ int main(int argc, char**argv)
     const char *ph="empty_ph";
     const char *th="empty_th";
 
-    gdriver_init(argc, argv, handlers_file, hh, ph, th);
-    gdriver_set_packet_fill_callback(fill_packet);
-   
+    gdriver_init(argc, argv);
+    gdriver_add_ectx(handlers_file, hh, ph, th, fill_packet, NULL, 42);
+
     gdriver_run();
 
     return (gdriver_fini()) ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/examples/filtering/driver/driver.c
+++ b/examples/filtering/driver/driver.c
@@ -62,13 +62,12 @@ int main(int argc, char **argv)
 
     srand(SEED);
 
-    gdriver_init(argc, argv, handlers_file, hh, ph, th);
-    gdriver_set_packet_fill_callback(fill_packet);
-
     uint32_t *vec = (uint32_t *)malloc(sizeof(uint32_t) * (TOT_WORDS));
     fill_htable(vec, TOT_WORDS);
 
-    gdriver_set_l2_img((void *)vec, sizeof(uint32_t) * (TOT_WORDS));
+    gdriver_init(argc, argv);
+    gdriver_add_ectx(handlers_file, hh, ph, th, fill_packet,
+        (void *)vec, sizeof(uint32_t) * (TOT_WORDS));
 
     gdriver_run();
 

--- a/examples/generic_driver/gdriver.h
+++ b/examples/generic_driver/gdriver.h
@@ -1,11 +1,11 @@
 // Copyright 2020 ETH Zurich
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#define GDRIVER_OK 0 
+#define GDRIVER_OK 0
 #define GDRIVER_ERR 1
 
 #include <stdint.h>
@@ -22,9 +22,8 @@
 
 typedef uint32_t (*fill_packet_fun_t)(uint32_t, uint32_t, uint8_t*, uint32_t, uint32_t*);
 
-
-int gdriver_init(int argc, char** argv, const char* hfile, const char* hh, const char* ph, const char* th);
-int gdriver_fini();
-int gdriver_set_packet_fill_callback(fill_packet_fun_t pkt_fill_fun);
-int gdriver_set_l2_img(void *img, size_t size);
+int gdriver_add_ectx(const char *hfile, const char *hh, const char *ph, const char *th,
+    fill_packet_fun_t fill_cb, void *l2_img, size_t l2_img_size);
 int gdriver_run();
+int gdriver_fini();
+int gdriver_init(int argc, char **argv);

--- a/examples/histogram/driver/driver.c
+++ b/examples/histogram/driver/driver.c
@@ -20,7 +20,7 @@
 #define SEED 236695
 
 uint32_t fill_packet(uint32_t msg_idx, uint32_t pkt_idx, uint8_t *pkt_buff, uint32_t max_pkt_size, uint32_t* l1_pkt_size)
-{   
+{
     pkt_hdr_t *hdr = (pkt_hdr_t*) pkt_buff;
     hdr->ip_hdr.ihl = 5;
     hdr->ip_hdr.length = max_pkt_size;
@@ -45,8 +45,8 @@ int main(int argc, char**argv)
 
     srand(SEED);
 
-    gdriver_init(argc, argv, handlers_file, hh, ph, th);
-    gdriver_set_packet_fill_callback(fill_packet);
+    gdriver_init(argc, argv);
+    gdriver_add_ectx(handlers_file, hh, ph, th, fill_packet, NULL, 42);
 
     gdriver_run();
 

--- a/examples/host_direct/driver/driver.c
+++ b/examples/host_direct/driver/driver.c
@@ -23,7 +23,8 @@ int main(int argc, char**argv)
     const char *ph="hostdirect_ph";
     const char *th=NULL;
 
-    gdriver_init(argc, argv, handlers_file, hh, ph, th);
+    gdriver_init(argc, argv);
+    gdriver_add_ectx(handlers_file, hh, ph, th, NULL, NULL, 42);
 
     gdriver_run();
 

--- a/examples/ooorb/driver/driver.c
+++ b/examples/ooorb/driver/driver.c
@@ -19,7 +19,7 @@ static uint32_t seqnum;
 
 
 uint32_t fill_packet(uint32_t msg_idx, uint32_t pkt_idx, uint8_t *pkt_buff, uint32_t max_pkt_size, uint32_t* l1_pkt_size)
-{   
+{
     // nothing to do here
 
     uint32_t* int_buf = (uint32_t*) pkt_buff;
@@ -32,11 +32,11 @@ uint32_t fill_packet(uint32_t msg_idx, uint32_t pkt_idx, uint8_t *pkt_buff, uint
         int_buf[0] = 0;
         int_buf[1] = pkt_idx*range_size;
         int_buf[2] = (pkt_idx+1)*range_size - 1;
-    } 
+    }
     else if (pkt_idx <= 30)
     {
         int_buf[0] = 1;
-    } 
+    }
     return max_pkt_size;
 }
 
@@ -49,9 +49,9 @@ int main(int argc, char**argv)
 
     seqnum = 0;
 
-    gdriver_init(argc, argv, handlers_file, hh, ph, th);
-    gdriver_set_packet_fill_callback(fill_packet);
-   
+    gdriver_init(argc, argv);
+    gdriver_add_ectx(handlers_file, hh, ph, th, fill_packet, NULL, 42);
+
     gdriver_run();
 
     return (gdriver_fini()) ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/examples/ping_pong/driver/driver.c
+++ b/examples/ping_pong/driver/driver.c
@@ -23,7 +23,8 @@ int main(int argc, char**argv)
     const char *ph="pingpong_ph";
     const char *th=NULL;
 
-    gdriver_init(argc, argv, handlers_file, hh, ph, th);
+    gdriver_init(argc, argv);
+    gdriver_add_ectx(handlers_file, hh, ph, th, NULL, NULL, 42);
 
     gdriver_run();
 

--- a/examples/slp/driver/driver.c
+++ b/examples/slp/driver/driver.c
@@ -152,11 +152,11 @@ int main(int argc, char**argv)
 
     predict_only = getenv("PREDICT_ONLY") != NULL;
     if (predict_only) {
-      printf("Note: running prediction only");
+        printf("Note: running prediction only");
     }
 
-    gdriver_init(argc, argv, handlers_file, hh, ph, th);
-    gdriver_set_packet_fill_callback(fill_packet);
+    gdriver_init(argc, argv);
+    gdriver_add_ectx(handlers_file, hh, ph, th, fill_packet, NULL, 42);
 
     gdriver_run();
 


### PR DESCRIPTION
This commit introduces API for multiple execution contexts:
 - gdriver_init(...) initializes simulation engine;
 - gdriver_add_ectx(...) adds new execution context associated with HH/PH/TH handlers, fill packet callback and L2 image to copy in PsPIN L2 memory;
 - aggragate_and_reduce shows an example usage of new API.

Now maximum number of execution contexts is controlled through EC_MAX_NUM macro variable which is set to 1 by default in order to maintain filtering example functionality. Host/L1/L2 memory is evenly divided between execution contexts, i.e. all execution contexts get a chunk of memory of equal size. To increase it, EC_MAX_NUM variable is needed to be reduced.